### PR TITLE
feat: add fallback for window width

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ easily create complex multi-column command-line-interfaces.
 ## Example
 
 ```js
-var ui = require('cliui')({
-  width: 80
-})
+var ui = require('cliui')()
 
 ui.div('Usage: $0 [command] [options]')
 
@@ -88,6 +86,7 @@ cliui = require('cliui')
 ### cliui({width: integer})
 
 Specify the maximum width of the UI being generated.
+If no width is provided, cliui will try to get the current window's width and use it, and if that doesn't work, width will be set to `80`.
 
 ### cliui({wrap: boolean})
 

--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ module.exports = function (opts) {
   opts = opts || {}
 
   return new UI({
-    width: (opts || {}).width || 80,
+    width: (opts || {}).width || process.stdout.columns || 80,
     wrap: typeof opts.wrap === 'boolean' ? opts.wrap : true
   })
 }

--- a/index.js
+++ b/index.js
@@ -283,7 +283,7 @@ function _minWidth (col) {
 }
 
 function getWindowWidth () {
-  if (process && process.stdout && process.stdout.columns) return process.stdout.columns
+  if (typeof process === 'object' && process.stdout && process.stdout.columns) return process.stdout.columns
 }
 
 function alignRight (str, width) {

--- a/index.js
+++ b/index.js
@@ -282,6 +282,10 @@ function _minWidth (col) {
   return minWidth
 }
 
+function getWindowWidth () {
+  if (process && process.stdout && process.stdout.columns) return process.stdout.columns
+}
+
 function alignRight (str, width) {
   str = str.trim()
   var padding = ''
@@ -310,7 +314,7 @@ module.exports = function (opts) {
   opts = opts || {}
 
   return new UI({
-    width: (opts || {}).width || process.stdout.columns || 80,
+    width: (opts || {}).width || getWindowWidth() || 80,
     wrap: typeof opts.wrap === 'boolean' ? opts.wrap : true
   })
 }


### PR DESCRIPTION
This adds a little fallback which returns the window width of the current window when no width is passed using the API.

If this PR gets merged, we could just not pass any width to cliui in yargs [instead of requiring the rather expensive `window-size`](https://github.com/yargs/yargs/blob/master/lib/usage.js#L399).
