### PR TITLE
Document the `text` property of a column

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Create a row with any number of columns, a column
 can either be a string, or an object with the following
 options:
 
+* **text:** some text to place in the column.
 * **width:** the width of a column.
 * **align:** alignment, `right` or `center`.
 * **padding:** `[top, right, bottom, left]`.


### PR DESCRIPTION
The `text` property of column objects was not mentioned in the README.  I found it by looking around the source code, and thought it might save the next person a little time if it were mentioned along with the other column properties.