### PR TITLE
Drop support for node < 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
-  - "5"
+  - "6"
+  - "8"
 after_script: npm run coverage

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
   "dependencies": {
-    "string-width": "^1.0.1",
-    "strip-ansi": "^3.0.1",
+    "string-width": "^2.1.1",
+    "strip-ansi": "^4.0.0",
     "wrap-ansi": "^2.0.0"
   },
   "devDependencies": {
@@ -60,5 +60,8 @@
   },
   "files": [
     "index.js"
-  ]
+  ],
+  "engine": {
+    "node": ">=4"
+  }
 }


### PR DESCRIPTION
This unblocks upgrades for some dependencies, enabling deduplication with `yargs` again.