### PR TITLE
Downgrades strip-ansi to version 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "license": "ISC",
   "dependencies": {
     "string-width": "^2.1.1",
-    "strip-ansi": "^4.0.0",
+    "strip-ansi": "^3.0.1",
     "wrap-ansi": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Partially reverts 185a77eaa567b6973b74c94286533fe626d70138

It's a guess but I think this is the package that broke it🤞