### PR TITLE
Revert "fix: downgrades strip-ansi to version 3.0.1 (#54)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "license": "ISC",
   "dependencies": {
     "string-width": "^2.1.1",
-    "strip-ansi": "^3.0.1",
+    "strip-ansi": "^4.0.0",
     "wrap-ansi": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This reverts commit 5764c4683250d08e3d8f59c92ea4f25a06c73897.

I enabled travis-ci for my github fork of cliui and was unable to reproduce the build failure.  Posting this pull request to see if the issue has resolved itself, or if somehow my travis-ci account tests this commit differently.