### PR TITLE
Set env variable FORCE_COLOR.

### DIFF
--- a/test/cliui.js
+++ b/test/cliui.js
@@ -2,6 +2,9 @@
 
 require('chai').should()
 
+// Force chalk to enable color, if it's disabled the test fails.
+process.env['FORCE_COLOR'] = 1
+
 var chalk = require('chalk')
 var cliui = require('../')
 var stripAnsi = require('strip-ansi')


### PR DESCRIPTION
This ensures that chalk uses always color instead of detecting from the
environment.  I believe when travis-ci runs the test it chalk detects
that color is not support.

The failure can be reproduced locally (without this patch) by running:
```shell
# Fails
env -i npm test --scripts-prepend-node-path

# Passes due to TERM environment
env -i TERM=xterm npm test --scripts-prepend-node-path
```

I set FORCE_COLOR as it's documented by chalk as how to disable detection.