### PR TITLE
Add clearText method

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,7 @@ options:
 
 Similar to `div`, except the next row will be appended without
 a new line being created.
+
+### cliui.clearText()
+
+Resets the text property of the current cliui.  Wrapping, width, margin, padding, border, and align set in the constructor are not reset.

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var right = 1
 var bottom = 2
 var left = 3
 
-function UI(opts) {
+function UI (opts) {
   this.width = opts.width
   this.wrap = opts.wrap
   this.rows = []
@@ -20,7 +20,6 @@ UI.prototype.span = function () {
   var cols = this.div.apply(this, arguments)
   cols.span = true
 }
-
 
 UI.prototype.clear = function () {
   this.rows = []
@@ -169,7 +168,7 @@ UI.prototype.rowToString = function (row, lines) {
   return lines
 }
 
-function addBorder(col, ts, style) {
+function addBorder (col, ts, style) {
   if (col.border) {
     if (/[.']-+[.']/.test(ts)) return ''
     else if (ts.trim().length) return style
@@ -280,18 +279,18 @@ UI.prototype._columnWidths = function (row) {
 
 // calculates the minimum width of
 // a column, based on padding preferences.
-function _minWidth(col) {
+function _minWidth (col) {
   var padding = col.padding || []
   var minWidth = 1 + (padding[left] || 0) + (padding[right] || 0)
   if (col.border) minWidth += 4
   return minWidth
 }
 
-function getWindowWidth() {
+function getWindowWidth () {
   if (typeof process === 'object' && process.stdout && process.stdout.columns) return process.stdout.columns
 }
 
-function alignRight(str, width) {
+function alignRight (str, width) {
   str = str.trim()
   var padding = ''
   var strWidth = stringWidth(str)
@@ -303,7 +302,7 @@ function alignRight(str, width) {
   return padding + str
 }
 
-function alignCenter(str, width) {
+function alignCenter (str, width) {
   str = str.trim()
   var padding = ''
   var strWidth = stringWidth(str.trim())

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var right = 1
 var bottom = 2
 var left = 3
 
-function UI (opts) {
+function UI(opts) {
   this.width = opts.width
   this.wrap = opts.wrap
   this.rows = []
@@ -19,6 +19,11 @@ function UI (opts) {
 UI.prototype.span = function () {
   var cols = this.div.apply(this, arguments)
   cols.span = true
+}
+
+
+UI.prototype.clear = function () {
+  this.rows = []
 }
 
 UI.prototype.div = function () {
@@ -164,7 +169,7 @@ UI.prototype.rowToString = function (row, lines) {
   return lines
 }
 
-function addBorder (col, ts, style) {
+function addBorder(col, ts, style) {
   if (col.border) {
     if (/[.']-+[.']/.test(ts)) return ''
     else if (ts.trim().length) return style
@@ -209,7 +214,7 @@ UI.prototype._rasterize = function (row) {
   row.forEach(function (col, c) {
     // leave room for left and right padding.
     col.width = widths[c]
-    if (_this.wrap) wrapped = wrap(col.text, _this._negatePadding(col), {hard: true}).split('\n')
+    if (_this.wrap) wrapped = wrap(col.text, _this._negatePadding(col), { hard: true }).split('\n')
     else wrapped = col.text.split('\n')
 
     if (col.border) {
@@ -275,18 +280,18 @@ UI.prototype._columnWidths = function (row) {
 
 // calculates the minimum width of
 // a column, based on padding preferences.
-function _minWidth (col) {
+function _minWidth(col) {
   var padding = col.padding || []
   var minWidth = 1 + (padding[left] || 0) + (padding[right] || 0)
   if (col.border) minWidth += 4
   return minWidth
 }
 
-function getWindowWidth () {
+function getWindowWidth() {
   if (typeof process === 'object' && process.stdout && process.stdout.columns) return process.stdout.columns
 }
 
-function alignRight (str, width) {
+function alignRight(str, width) {
   str = str.trim()
   var padding = ''
   var strWidth = stringWidth(str)
@@ -298,7 +303,7 @@ function alignRight (str, width) {
   return padding + str
 }
 
-function alignCenter (str, width) {
+function alignCenter(str, width) {
   str = str.trim()
   var padding = ''
   var strWidth = stringWidth(str.trim())

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ UI.prototype.span = function () {
   cols.span = true
 }
 
-UI.prototype.clear = function () {
+UI.prototype.clearText = function () {
   this.rows = []
 }
 

--- a/test/cliui.js
+++ b/test/cliui.js
@@ -14,7 +14,7 @@ describe('cliui', function () {
     it('should set lines to empty', function () {
       var ui = cliui()
       ui.div('i am a value that would be in a line')
-      ui.clear()
+      ui.clearText()
       ui.toString().length.should.be.equal(0)
     })
   })

--- a/test/cliui.js
+++ b/test/cliui.js
@@ -10,7 +10,7 @@ var cliui = require('../')
 var stripAnsi = require('strip-ansi')
 
 describe('cliui', function () {
-  describe('clear', function () {
+  describe('clearText', function () {
     it('should set lines to empty', function () {
       var ui = cliui()
       ui.div('i am a value that would be in a line')

--- a/test/cliui.js
+++ b/test/cliui.js
@@ -10,6 +10,15 @@ var cliui = require('../')
 var stripAnsi = require('strip-ansi')
 
 describe('cliui', function () {
+  describe('clear', function () {
+    it('should set lines to empty', function () {
+      var ui = cliui()
+      ui.div('i am a value that would be in a line')
+      ui.clear()
+      ui.toString().length.should.be.equal(0)
+    })
+  })
+
   describe('div', function () {
     it("wraps text at 'width' if a single column is given", function () {
       var ui = cliui({
@@ -29,7 +38,7 @@ describe('cliui', function () {
       })
 
       ui.div(
-        {text: 'i am a string that should be wrapped', width: 15},
+        { text: 'i am a string that should be wrapped', width: 15 },
         'i am a second string that should be wrapped',
         'i am a third string that should be wrapped'
       )
@@ -82,7 +91,7 @@ describe('cliui', function () {
       var ui = cliui({
         width: 40
       })
-      var widths = ui._columnWidths([{width: 20}, {}, {}])
+      var widths = ui._columnWidths([{ width: 20 }, {}, {}])
 
       widths[0].should.equal(20)
       widths[1].should.equal(10)
@@ -93,7 +102,7 @@ describe('cliui', function () {
       var ui = cliui({
         width: 40
       })
-      var widths = ui._columnWidths([{}, {width: 10}, {}])
+      var widths = ui._columnWidths([{}, { width: 10 }, {}])
 
       widths[0].should.equal(15)
       widths[1].should.equal(10)
@@ -104,7 +113,7 @@ describe('cliui', function () {
       var ui = cliui({
         width: 40
       })
-      var widths = ui._columnWidths([{width: 20}, {width: 12}, {}])
+      var widths = ui._columnWidths([{ width: 20 }, { width: 12 }, {}])
 
       widths[0].should.equal(20)
       widths[1].should.equal(12)
@@ -115,7 +124,7 @@ describe('cliui', function () {
       var ui = cliui({
         width: 40
       })
-      var widths = ui._columnWidths([{width: 30}, {width: 30}, {padding: [0, 2, 0, 1]}])
+      var widths = ui._columnWidths([{ width: 30 }, { width: 30 }, { padding: [0, 2, 0, 1] }])
 
       widths[0].should.equal(30)
       widths[1].should.equal(30)
@@ -131,7 +140,7 @@ describe('cliui', function () {
 
       ui.div(
         'i am a string',
-        {text: 'i am a second string', align: 'right'},
+        { text: 'i am a second string', align: 'right' },
         'i am a third string that should be wrapped'
       )
 
@@ -153,7 +162,7 @@ describe('cliui', function () {
 
       ui.div(
         'i am a string',
-        {text: 'i am a second string', align: 'center', padding: [0, 2, 0, 2]},
+        { text: 'i am a second string', align: 'center', padding: [0, 2, 0, 2] },
         'i am a third string that should be wrapped'
       )
 
@@ -175,9 +184,9 @@ describe('cliui', function () {
       })
 
       ui.div(
-        {text: 'i have padding on my left', padding: [0, 0, 0, 4]},
-        {text: 'i have padding on my right', padding: [0, 2, 0, 0], align: 'center'},
-        {text: 'i have no padding', padding: [0, 0, 0, 0]}
+        { text: 'i have padding on my left', padding: [0, 0, 0, 4] },
+        { text: 'i have padding on my right', padding: [0, 2, 0, 0], align: 'center' },
+        { text: 'i have no padding', padding: [0, 0, 0, 0] }
       )
 
       // it should add left/right padding to columns.
@@ -198,8 +207,8 @@ describe('cliui', function () {
 
       ui.div(
         'i am a string',
-        {text: 'i am a second string', padding: [2, 0, 0, 0]},
-        {text: 'i am a third string that should be wrapped', padding: [0, 0, 1, 0]}
+        { text: 'i am a second string', padding: [2, 0, 0, 0] },
+        { text: 'i am a third string that should be wrapped', padding: [0, 0, 1, 0] }
       )
 
       // it should add top/bottom padding to second
@@ -239,8 +248,8 @@ describe('cliui', function () {
       })
 
       ui.div(
-        {text: 'i am a first string', padding: [0, 0, 0, 0], border: true},
-        {text: 'i am a second string', padding: [1, 0, 0, 0], border: true}
+        { text: 'i am a first string', padding: [0, 0, 0, 0], border: true },
+        { text: 'i am a second string', padding: [1, 0, 0, 0], border: true }
       )
 
       var expected = [
@@ -262,9 +271,9 @@ describe('cliui', function () {
       })
 
       ui.div(
-        {text: 'i am a string', padding: [0, 1, 0, 0]},
-        {text: 'i am a second string', padding: [0, 2, 0, 0]},
-        {text: 'i am a third string that should not be wrapped', padding: [0, 0, 0, 2]}
+        { text: 'i am a string', padding: [0, 1, 0, 0] },
+        { text: 'i am a second string', padding: [0, 2, 0, 0] },
+        { text: 'i am a third string that should not be wrapped', padding: [0, 0, 0, 2] }
       )
 
       ui.toString().should.equal('i am a string i am a second string    i am a third string that should not be wrapped')
@@ -278,11 +287,11 @@ describe('cliui', function () {
       })
 
       ui.span(
-        {text: 'i am a string that will be wrapped', width: 30}
+        { text: 'i am a string that will be wrapped', width: 30 }
       )
 
       ui.div(
-        {text: ' [required] [default: 99]', align: 'right'}
+        { text: ' [required] [default: 99]', align: 'right' }
       )
 
       var expected = [
@@ -299,11 +308,11 @@ describe('cliui', function () {
       })
 
       ui.span(
-        {text: 'i am a string that will be wrapped', width: 30}
+        { text: 'i am a string that will be wrapped', width: 30 }
       )
 
       ui.div(
-        {text: 'i am a second row', align: 'left'}
+        { text: 'i am a second row', align: 'left' }
       )
 
       var expected = [
@@ -322,11 +331,11 @@ describe('cliui', function () {
       })
 
       ui.span(
-        {text: 'i am a string that will be wrapped', width: 30}
+        { text: 'i am a string that will be wrapped', width: 30 }
       )
 
       ui.div(
-        {text: 'i am a second row', align: 'left', padding: [0, 0, 0, 3]}
+        { text: 'i am a second row', align: 'left', padding: [0, 0, 0, 3] }
       )
 
       ui.div('a third line')
@@ -345,11 +354,11 @@ describe('cliui', function () {
       })
 
       ui.span(
-        {text: chalk.green('i am a string that will be wrapped'), width: 30}
+        { text: chalk.green('i am a string that will be wrapped'), width: 30 }
       )
 
       ui.div(
-        {text: chalk.blue(' [required] [default: 99]'), align: 'right'}
+        { text: chalk.blue(' [required] [default: 99]'), align: 'right' }
       )
 
       var expected = [


### PR DESCRIPTION
# Description
Added a clearText method that will clear out the text (the rows property) of the current cliui instance.  
Also fixed styling issue that made my testing fail.

## Problem to Solve
Before, you needed to call require('cliui')() again to clear out the text property.  This would also clear out any other options you gave it.  I wanted to reset the text and maintain other options already set.

## Proposed Changes
Add a function named clearText to the UI prototype.

## Expected Behavior
When you call cliui.clearText() the rows property will be set to [], allowing you to reset the text value but maintain the other styling / options you set without having to call require('cliui')() again.

## Steps to Test Solution
1. Run `npm install`
1.
     ```
     'use strict'
     var ui = require('./index')({width: 5})
     ui.div('i am a value that would be in a line')
     console.log("There should be text:", ui.toString())
     ui.clearText()
     console.log("There should be no text:", ui.toString())
     ui.div(`This should print out once and not have 'i am a value that would be in a line' printed out with it.`)
     console.log("This should still have width of 5:", ui.toString())
``

1. Run `npm test`
to verify that all tests passed.