### PR TITLE
chore: Update code to use ES2015

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,324 +1,355 @@
-var stringWidth = require('string-width')
-var stripAnsi = require('strip-ansi')
-var wrap = require('wrap-ansi')
-var align = {
+const stringWidth = require('string-width')
+const stripAnsi = require('strip-ansi')
+const wrap = require('wrap-ansi')
+
+const align = {
   right: alignRight,
   center: alignCenter
 }
-var top = 0
-var right = 1
-var bottom = 2
-var left = 3
+const top = 0
+const right = 1
+const bottom = 2
+const left = 3
 
-function UI (opts) {
-  this.width = opts.width
-  this.wrap = opts.wrap
-  this.rows = []
-}
-
-UI.prototype.span = function () {
-  var cols = this.div.apply(this, arguments)
-  cols.span = true
-}
-
-UI.prototype.resetOutput = function () {
-  this.rows = []
-}
-
-UI.prototype.div = function () {
-  if (arguments.length === 0) this.div('')
-  if (this.wrap && this._shouldApplyLayoutDSL.apply(this, arguments)) {
-    return this._applyLayoutDSL(arguments[0])
+class UI {
+  constructor (opts) {
+    this.width = opts.width
+    this.wrap = opts.wrap
+    this.rows = []
   }
 
-  var cols = []
-
-  for (var i = 0, arg; (arg = arguments[i]) !== undefined; i++) {
-    if (typeof arg === 'string') cols.push(this._colFromString(arg))
-    else cols.push(arg)
+  span (...args) {
+    const cols = this.div(...args)
+    cols.span = true
   }
 
-  this.rows.push(cols)
-  return cols
-}
+  resetOutput () {
+    this.rows = []
+  }
 
-UI.prototype._shouldApplyLayoutDSL = function () {
-  return arguments.length === 1 && typeof arguments[0] === 'string' &&
-    /[\t\n]/.test(arguments[0])
-}
-
-UI.prototype._applyLayoutDSL = function (str) {
-  var _this = this
-  var rows = str.split('\n')
-  var leftColumnWidth = 0
-
-  // simple heuristic for layout, make sure the
-  // second column lines up along the left-hand.
-  // don't allow the first column to take up more
-  // than 50% of the screen.
-  rows.forEach(function (row) {
-    var columns = row.split('\t')
-    if (columns.length > 1 && stringWidth(columns[0]) > leftColumnWidth) {
-      leftColumnWidth = Math.min(
-        Math.floor(_this.width * 0.5),
-        stringWidth(columns[0])
-      )
+  div (...args) {
+    if (args.length === 0) {
+      this.div('')
     }
-  })
 
-  // generate a table:
-  //  replacing ' ' with padding calculations.
-  //  using the algorithmically generated width.
-  rows.forEach(function (row) {
-    var columns = row.split('\t')
-    _this.div.apply(_this, columns.map(function (r, i) {
-      return {
-        text: r.trim(),
-        padding: _this._measurePadding(r),
-        width: (i === 0 && columns.length > 1) ? leftColumnWidth : undefined
+    if (this.wrap && this._shouldApplyLayoutDSL(...args)) {
+      return this._applyLayoutDSL(args[0])
+    }
+
+    const cols = args.map(arg => {
+      if (typeof arg === 'string') {
+        return this._colFromString(arg)
       }
-    }))
-  })
 
-  return this.rows[this.rows.length - 1]
-}
+      return arg
+    })
 
-UI.prototype._colFromString = function (str) {
-  return {
-    text: str,
-    padding: this._measurePadding(str)
+    this.rows.push(cols)
+    return cols
   }
-}
 
-UI.prototype._measurePadding = function (str) {
-  // measure padding without ansi escape codes
-  var noAnsi = stripAnsi(str)
-  return [0, noAnsi.match(/\s*$/)[0].length, 0, noAnsi.match(/^\s*/)[0].length]
-}
+  _shouldApplyLayoutDSL (...args) {
+    return args.length === 1 && typeof args[0] === 'string' &&
+      /[\t\n]/.test(args[0])
+  }
 
-UI.prototype.toString = function () {
-  var _this = this
-  var lines = []
+  _applyLayoutDSL (str) {
+    const rows = str.split('\n').map(row => row.split('\t'))
+    let leftColumnWidth = 0
 
-  _this.rows.forEach(function (row, i) {
-    _this.rowToString(row, lines)
-  })
-
-  // don't display any lines with the
-  // hidden flag set.
-  lines = lines.filter(function (line) {
-    return !line.hidden
-  })
-
-  return lines.map(function (line) {
-    return line.text
-  }).join('\n')
-}
-
-UI.prototype.rowToString = function (row, lines) {
-  var _this = this
-  var padding
-  var rrows = this._rasterize(row)
-  var str = ''
-  var ts
-  var width
-  var wrapWidth
-
-  rrows.forEach(function (rrow, r) {
-    str = ''
-    rrow.forEach(function (col, c) {
-      ts = '' // temporary string used during alignment/padding.
-      width = row[c].width // the width with padding.
-      wrapWidth = _this._negatePadding(row[c]) // the width without padding.
-
-      ts += col
-
-      for (var i = 0; i < wrapWidth - stringWidth(col); i++) {
-        ts += ' '
-      }
-
-      // align the string within its column.
-      if (row[c].align && row[c].align !== 'left' && _this.wrap) {
-        ts = align[row[c].align](ts, wrapWidth)
-        if (stringWidth(ts) < wrapWidth) ts += new Array(width - stringWidth(ts)).join(' ')
-      }
-
-      // apply border and padding to string.
-      padding = row[c].padding || [0, 0, 0, 0]
-      if (padding[left]) str += new Array(padding[left] + 1).join(' ')
-      str += addBorder(row[c], ts, '| ')
-      str += ts
-      str += addBorder(row[c], ts, ' |')
-      if (padding[right]) str += new Array(padding[right] + 1).join(' ')
-
-      // if prior row is span, try to render the
-      // current row on the prior line.
-      if (r === 0 && lines.length > 0) {
-        str = _this._renderInline(str, lines[lines.length - 1])
+    // simple heuristic for layout, make sure the
+    // second column lines up along the left-hand.
+    // don't allow the first column to take up more
+    // than 50% of the screen.
+    rows.forEach(columns => {
+      if (columns.length > 1 && stringWidth(columns[0]) > leftColumnWidth) {
+        leftColumnWidth = Math.min(
+          Math.floor(this.width * 0.5),
+          stringWidth(columns[0])
+        )
       }
     })
 
-    // remove trailing whitespace.
-    lines.push({
-      text: str.replace(/ +$/, ''),
-      span: row.span
+    // generate a table:
+    //  replacing ' ' with padding calculations.
+    //  using the algorithmically generated width.
+    rows.forEach(columns => {
+      this.div(...columns.map((r, i) => {
+        return {
+          text: r.trim(),
+          padding: this._measurePadding(r),
+          width: (i === 0 && columns.length > 1) ? leftColumnWidth : undefined
+        }
+      }))
     })
-  })
 
-  return lines
+    return this.rows[this.rows.length - 1]
+  }
+
+  _colFromString (text) {
+    return {
+      text,
+      padding: this._measurePadding(text)
+    }
+  }
+
+  _measurePadding (str) {
+    // measure padding without ansi escape codes
+    const noAnsi = stripAnsi(str)
+    return [0, noAnsi.match(/\s*$/)[0].length, 0, noAnsi.match(/^\s*/)[0].length]
+  }
+
+  toString () {
+    const lines = []
+
+    this.rows.forEach(row => {
+      this.rowToString(row, lines)
+    })
+
+    // don't display any lines with the
+    // hidden flag set.
+    return lines
+      .filter(line => !line.hidden)
+      .map(line => line.text)
+      .join('\n')
+  }
+
+  rowToString (row, lines) {
+    this._rasterize(row).forEach((rrow, r) => {
+      let str = ''
+      rrow.forEach((col, c) => {
+        const { width } = row[c] // the width with padding.
+        const wrapWidth = this._negatePadding(row[c]) // the width without padding.
+
+        let ts = col // temporary string used during alignment/padding.
+
+        for (let i = 0; i < wrapWidth - stringWidth(col); i++) {
+          ts += ' '
+        }
+
+        // align the string within its column.
+        if (row[c].align && row[c].align !== 'left' && this.wrap) {
+          ts = align[row[c].align](ts, wrapWidth)
+          if (stringWidth(ts) < wrapWidth) {
+            ts += new Array(width - stringWidth(ts)).join(' ')
+          }
+        }
+
+        // apply border and padding to string.
+        const padding = row[c].padding || [0, 0, 0, 0]
+        if (padding[left]) {
+          str += new Array(padding[left] + 1).join(' ')
+        }
+
+        str += addBorder(row[c], ts, '| ')
+        str += ts
+        str += addBorder(row[c], ts, ' |')
+        if (padding[right]) {
+          str += new Array(padding[right] + 1).join(' ')
+        }
+
+        // if prior row is span, try to render the
+        // current row on the prior line.
+        if (r === 0 && lines.length > 0) {
+          str = this._renderInline(str, lines[lines.length - 1])
+        }
+      })
+
+      // remove trailing whitespace.
+      lines.push({
+        text: str.replace(/ +$/, ''),
+        span: row.span
+      })
+    })
+
+    return lines
+  }
+
+  // if the full 'source' can render in
+  // the target line, do so.
+  _renderInline (source, previousLine) {
+    const leadingWhitespace = source.match(/^ */)[0].length
+    const target = previousLine.text
+    const targetTextWidth = stringWidth(target.trimRight())
+
+    if (!previousLine.span) {
+      return source
+    }
+
+    // if we're not applying wrapping logic,
+    // just always append to the span.
+    if (!this.wrap) {
+      previousLine.hidden = true
+      return target + source
+    }
+
+    if (leadingWhitespace < targetTextWidth) {
+      return source
+    }
+
+    previousLine.hidden = true
+
+    return target.trimRight() + new Array(leadingWhitespace - targetTextWidth + 1).join(' ') + source.trimLeft()
+  }
+
+  _rasterize (row) {
+    const rrows = []
+    const widths = this._columnWidths(row)
+    let wrapped
+
+    // word wrap all columns, and create
+    // a data-structure that is easy to rasterize.
+    row.forEach((col, c) => {
+      // leave room for left and right padding.
+      col.width = widths[c]
+      if (this.wrap) {
+        wrapped = wrap(col.text, this._negatePadding(col), { hard: true }).split('\n')
+      } else {
+        wrapped = col.text.split('\n')
+      }
+
+      if (col.border) {
+        wrapped.unshift('.' + new Array(this._negatePadding(col) + 3).join('-') + '.')
+        wrapped.push("'" + new Array(this._negatePadding(col) + 3).join('-') + "'")
+      }
+
+      // add top and bottom padding.
+      if (col.padding) {
+        for (let i = 0; i < (col.padding[top] || 0); i++) {
+          wrapped.unshift('')
+        }
+
+        for (let i = 0; i < (col.padding[bottom] || 0); i++) {
+          wrapped.push('')
+        }
+      }
+
+      wrapped.forEach((str, r) => {
+        if (!rrows[r]) {
+          rrows.push([])
+        }
+
+        const rrow = rrows[r]
+
+        for (let i = 0; i < c; i++) {
+          if (rrow[i] === undefined) {
+            rrow.push('')
+          }
+        }
+
+        rrow.push(str)
+      })
+    })
+
+    return rrows
+  }
+
+  _negatePadding (col) {
+    let wrapWidth = col.width
+    if (col.padding) {
+      wrapWidth -= (col.padding[left] || 0) + (col.padding[right] || 0)
+    }
+
+    if (col.border) {
+      wrapWidth -= 4
+    }
+
+    return wrapWidth
+  }
+
+  _columnWidths (row) {
+    if (!this.wrap) {
+      return row.map(col => {
+        return col.width || stringWidth(col.text)
+      })
+    }
+
+    let unset = row.length
+    let remainingWidth = this.width
+
+    // column widths can be set in config.
+    const widths = row.map(col => {
+      if (col.width) {
+        unset--
+        remainingWidth -= col.width
+        return col.width
+      }
+
+      return undefined
+    })
+
+    // any unset widths should be calculated.
+    const unsetWidth = unset ? Math.floor(remainingWidth / unset) : 0
+
+    return widths.map((w, i) => {
+      if (w === undefined) {
+        return Math.max(unsetWidth, _minWidth(row[i]))
+      }
+
+      return w
+    })
+  }
 }
 
 function addBorder (col, ts, style) {
   if (col.border) {
-    if (/[.']-+[.']/.test(ts)) return ''
-    else if (ts.trim().length) return style
-    else return '  '
+    if (/[.']-+[.']/.test(ts)) {
+      return ''
+    }
+
+    if (ts.trim().length !== 0) {
+      return style
+    }
+
+    return '  '
   }
+
   return ''
-}
-
-// if the full 'source' can render in
-// the target line, do so.
-UI.prototype._renderInline = function (source, previousLine) {
-  var leadingWhitespace = source.match(/^ */)[0].length
-  var target = previousLine.text
-  var targetTextWidth = stringWidth(target.trimRight())
-
-  if (!previousLine.span) return source
-
-  // if we're not applying wrapping logic,
-  // just always append to the span.
-  if (!this.wrap) {
-    previousLine.hidden = true
-    return target + source
-  }
-
-  if (leadingWhitespace < targetTextWidth) return source
-
-  previousLine.hidden = true
-
-  return target.trimRight() + new Array(leadingWhitespace - targetTextWidth + 1).join(' ') + source.trimLeft()
-}
-
-UI.prototype._rasterize = function (row) {
-  var _this = this
-  var i
-  var rrow
-  var rrows = []
-  var widths = this._columnWidths(row)
-  var wrapped
-
-  // word wrap all columns, and create
-  // a data-structure that is easy to rasterize.
-  row.forEach(function (col, c) {
-    // leave room for left and right padding.
-    col.width = widths[c]
-    if (_this.wrap) wrapped = wrap(col.text, _this._negatePadding(col), { hard: true }).split('\n')
-    else wrapped = col.text.split('\n')
-
-    if (col.border) {
-      wrapped.unshift('.' + new Array(_this._negatePadding(col) + 3).join('-') + '.')
-      wrapped.push("'" + new Array(_this._negatePadding(col) + 3).join('-') + "'")
-    }
-
-    // add top and bottom padding.
-    if (col.padding) {
-      for (i = 0; i < (col.padding[top] || 0); i++) wrapped.unshift('')
-      for (i = 0; i < (col.padding[bottom] || 0); i++) wrapped.push('')
-    }
-
-    wrapped.forEach(function (str, r) {
-      if (!rrows[r]) rrows.push([])
-
-      rrow = rrows[r]
-
-      for (var i = 0; i < c; i++) {
-        if (rrow[i] === undefined) rrow.push('')
-      }
-      rrow.push(str)
-    })
-  })
-
-  return rrows
-}
-
-UI.prototype._negatePadding = function (col) {
-  var wrapWidth = col.width
-  if (col.padding) wrapWidth -= (col.padding[left] || 0) + (col.padding[right] || 0)
-  if (col.border) wrapWidth -= 4
-  return wrapWidth
-}
-
-UI.prototype._columnWidths = function (row) {
-  var _this = this
-  var widths = []
-  var unset = row.length
-  var unsetWidth
-  var remainingWidth = this.width
-
-  // column widths can be set in config.
-  row.forEach(function (col, i) {
-    if (col.width) {
-      unset--
-      widths[i] = col.width
-      remainingWidth -= col.width
-    } else {
-      widths[i] = undefined
-    }
-  })
-
-  // any unset widths should be calculated.
-  if (unset) unsetWidth = Math.floor(remainingWidth / unset)
-  widths.forEach(function (w, i) {
-    if (!_this.wrap) widths[i] = row[i].width || stringWidth(row[i].text)
-    else if (w === undefined) widths[i] = Math.max(unsetWidth, _minWidth(row[i]))
-  })
-
-  return widths
 }
 
 // calculates the minimum width of
 // a column, based on padding preferences.
 function _minWidth (col) {
-  var padding = col.padding || []
-  var minWidth = 1 + (padding[left] || 0) + (padding[right] || 0)
-  if (col.border) minWidth += 4
+  const padding = col.padding || []
+  const minWidth = 1 + (padding[left] || 0) + (padding[right] || 0)
+  if (col.border) {
+    return minWidth + 4
+  }
+
   return minWidth
 }
 
 function getWindowWidth () {
-  if (typeof process === 'object' && process.stdout && process.stdout.columns) return process.stdout.columns
+  if (typeof process === 'object' && process.stdout && process.stdout.columns) {
+    return process.stdout.columns
+  }
 }
 
 function alignRight (str, width) {
   str = str.trim()
-  var padding = ''
-  var strWidth = stringWidth(str)
+  const strWidth = stringWidth(str)
 
   if (strWidth < width) {
-    padding = new Array(width - strWidth + 1).join(' ')
+    return new Array(width - strWidth + 1).join(' ') + str
   }
 
-  return padding + str
+  return str
 }
 
 function alignCenter (str, width) {
   str = str.trim()
-  var padding = ''
-  var strWidth = stringWidth(str.trim())
+  const strWidth = stringWidth(str)
 
   if (strWidth < width) {
-    padding = new Array(parseInt((width - strWidth) / 2, 10) + 1).join(' ')
+    return new Array(parseInt((width - strWidth) / 2, 10) + 1).join(' ') + str
   }
 
-  return padding + str
+  return str
 }
 
-module.exports = function (opts) {
-  opts = opts || {}
-
+module.exports = function (opts = {}) {
   return new UI({
-    width: (opts || {}).width || getWindowWidth() || 80,
-    wrap: typeof opts.wrap === 'boolean' ? opts.wrap : true
+    width: opts.width || getWindowWidth() || 80,
+    wrap: opts.wrap !== false
   })
 }

--- a/test/cliui.js
+++ b/test/cliui.js
@@ -5,35 +5,35 @@ require('chai').should()
 // Force chalk to enable color, if it's disabled the test fails.
 process.env['FORCE_COLOR'] = 1
 
-var chalk = require('chalk')
-var cliui = require('../')
-var stripAnsi = require('strip-ansi')
+const chalk = require('chalk')
+const cliui = require('../')
+const stripAnsi = require('strip-ansi')
 
-describe('cliui', function () {
-  describe('resetOutput', function () {
-    it('should set lines to empty', function () {
-      var ui = cliui()
+describe('cliui', () => {
+  describe('resetOutput', () => {
+    it('should set lines to empty', () => {
+      const ui = cliui()
       ui.div('i am a value that would be in a line')
       ui.resetOutput()
       ui.toString().length.should.be.equal(0)
     })
   })
 
-  describe('div', function () {
-    it("wraps text at 'width' if a single column is given", function () {
-      var ui = cliui({
+  describe('div', () => {
+    it("wraps text at 'width' if a single column is given", () => {
+      const ui = cliui({
         width: 10
       })
 
       ui.div('i am a string that should be wrapped')
 
-      ui.toString().split('\n').forEach(function (row) {
+      ui.toString().split('\n').forEach(row => {
         row.length.should.be.lte(10)
       })
     })
 
-    it('evenly divides text across columns if multiple columns are given', function () {
-      var ui = cliui({
+    it('evenly divides text across columns if multiple columns are given', () => {
+      const ui = cliui({
         width: 40
       })
 
@@ -45,12 +45,12 @@ describe('cliui', function () {
 
       // total width of all columns is <=
       // the width cliui is initialized with.
-      ui.toString().split('\n').forEach(function (row) {
+      ui.toString().split('\n').forEach(row => {
         row.length.should.be.lte(40)
       })
 
       // it should wrap each column appropriately.
-      var expected = [
+      const expected = [
         'i am a string  i am a      i am a third',
         'that should be second      string that',
         'wrapped        string that should be',
@@ -61,70 +61,70 @@ describe('cliui', function () {
       ui.toString().split('\n').should.eql(expected)
     })
 
-    it('allows for a blank row to be appended', function () {
-      var ui = cliui({
+    it('allows for a blank row to be appended', () => {
+      const ui = cliui({
         width: 40
       })
 
       ui.div()
 
       // it should wrap each column appropriately.
-      var expected = ['']
+      const expected = ['']
 
       ui.toString().split('\n').should.eql(expected)
     })
   })
 
-  describe('_columnWidths', function () {
-    it('uses same width for each column by default', function () {
-      var ui = cliui({
+  describe('_columnWidths', () => {
+    it('uses same width for each column by default', () => {
+      const ui = cliui({
         width: 40
       })
-      var widths = ui._columnWidths([{}, {}, {}])
+      const widths = ui._columnWidths([{}, {}, {}])
 
       widths[0].should.equal(13)
       widths[1].should.equal(13)
       widths[2].should.equal(13)
     })
 
-    it('divides width over remaining columns if first column has width specified', function () {
-      var ui = cliui({
+    it('divides width over remaining columns if first column has width specified', () => {
+      const ui = cliui({
         width: 40
       })
-      var widths = ui._columnWidths([{ width: 20 }, {}, {}])
+      const widths = ui._columnWidths([{ width: 20 }, {}, {}])
 
       widths[0].should.equal(20)
       widths[1].should.equal(10)
       widths[2].should.equal(10)
     })
 
-    it('divides width over remaining columns if middle column has width specified', function () {
-      var ui = cliui({
+    it('divides width over remaining columns if middle column has width specified', () => {
+      const ui = cliui({
         width: 40
       })
-      var widths = ui._columnWidths([{}, { width: 10 }, {}])
+      const widths = ui._columnWidths([{}, { width: 10 }, {}])
 
       widths[0].should.equal(15)
       widths[1].should.equal(10)
       widths[2].should.equal(15)
     })
 
-    it('keeps track of remaining width if multiple columns have width specified', function () {
-      var ui = cliui({
+    it('keeps track of remaining width if multiple columns have width specified', () => {
+      const ui = cliui({
         width: 40
       })
-      var widths = ui._columnWidths([{ width: 20 }, { width: 12 }, {}])
+      const widths = ui._columnWidths([{ width: 20 }, { width: 12 }, {}])
 
       widths[0].should.equal(20)
       widths[1].should.equal(12)
       widths[2].should.equal(8)
     })
 
-    it('uses a sane default if impossible widths are specified', function () {
-      var ui = cliui({
+    it('uses a sane default if impossible widths are specified', () => {
+      const ui = cliui({
         width: 40
       })
-      var widths = ui._columnWidths([{ width: 30 }, { width: 30 }, { padding: [0, 2, 0, 1] }])
+      const widths = ui._columnWidths([{ width: 30 }, { width: 30 }, { padding: [0, 2, 0, 1] }])
 
       widths[0].should.equal(30)
       widths[1].should.equal(30)
@@ -132,9 +132,9 @@ describe('cliui', function () {
     })
   })
 
-  describe('alignment', function () {
-    it('allows a column to be right aligned', function () {
-      var ui = cliui({
+  describe('alignment', () => {
+    it('allows a column to be right aligned', () => {
+      const ui = cliui({
         width: 40
       })
 
@@ -145,7 +145,7 @@ describe('cliui', function () {
       )
 
       // it should right-align the second column.
-      var expected = [
+      const expected = [
         'i am a stringi am a secondi am a third',
         '                    stringstring that',
         '                          should be',
@@ -155,8 +155,8 @@ describe('cliui', function () {
       ui.toString().split('\n').should.eql(expected)
     })
 
-    it('allows a column to be center aligned', function () {
-      var ui = cliui({
+    it('allows a column to be center aligned', () => {
+      const ui = cliui({
         width: 60
       })
 
@@ -167,7 +167,7 @@ describe('cliui', function () {
       )
 
       // it should right-align the second column.
-      var expected = [
+      const expected = [
         'i am a string          i am a second       i am a third string',
         '                           string          that should be',
         '                                           wrapped'
@@ -177,9 +177,9 @@ describe('cliui', function () {
     })
   })
 
-  describe('padding', function () {
-    it('handles left/right padding', function () {
-      var ui = cliui({
+  describe('padding', () => {
+    it('handles left/right padding', () => {
+      const ui = cliui({
         width: 40
       })
 
@@ -190,7 +190,7 @@ describe('cliui', function () {
       )
 
       // it should add left/right padding to columns.
-      var expected = [
+      const expected = [
         '    i have     i have      i have no',
         '    padding  padding on    padding',
         '    on my     my right',
@@ -200,8 +200,8 @@ describe('cliui', function () {
       ui.toString().split('\n').should.eql(expected)
     })
 
-    it('handles top/bottom padding', function () {
-      var ui = cliui({
+    it('handles top/bottom padding', () => {
+      const ui = cliui({
         width: 40
       })
 
@@ -213,7 +213,7 @@ describe('cliui', function () {
 
       // it should add top/bottom padding to second
       // and third columns.
-      var expected = [
+      const expected = [
         'i am a string             i am a third',
         '                          string that',
         '             i am a secondshould be',
@@ -224,26 +224,24 @@ describe('cliui', function () {
       ui.toString().split('\n').should.eql(expected)
     })
 
-    it('preserves leading whitespace as padding', function () {
-      var ui = cliui()
+    it('preserves leading whitespace as padding', () => {
+      const ui = cliui()
 
       ui.div('     LEADING WHITESPACE')
       ui.div('\u001b[34m     with ansi\u001b[39m')
 
-      var expected = [
+      const expected = [
         '     LEADING WHITESPACE',
         '     with ansi'
       ]
 
-      ui.toString().split('\n').map(function (l) {
-        return stripAnsi(l)
-      }).should.eql(expected)
+      ui.toString().split('\n').map(l => stripAnsi(l)).should.eql(expected)
     })
   })
 
-  describe('border', function () {
-    it('allows a border to be placed around a div', function () {
-      var ui = cliui({
+  describe('border', () => {
+    it('allows a border to be placed around a div', () => {
+      const ui = cliui({
         width: 40
       })
 
@@ -252,7 +250,7 @@ describe('cliui', function () {
         { text: 'i am a second string', padding: [1, 0, 0, 0], border: true }
       )
 
-      var expected = [
+      const expected = [
         '.------------------.',
         '| i am a first     |.------------------.',
         '| string           || i am a second    |',
@@ -264,9 +262,9 @@ describe('cliui', function () {
     })
   })
 
-  describe('wrap', function () {
-    it('allows wordwrap to be disabled', function () {
-      var ui = cliui({
+  describe('wrap', () => {
+    it('allows wordwrap to be disabled', () => {
+      const ui = cliui({
         wrap: false
       })
 
@@ -280,9 +278,9 @@ describe('cliui', function () {
     })
   })
 
-  describe('span', function () {
-    it('appends the next row to the end of the prior row if it fits', function () {
-      var ui = cliui({
+  describe('span', () => {
+    it('appends the next row to the end of the prior row if it fits', () => {
+      const ui = cliui({
         width: 40
       })
 
@@ -294,7 +292,7 @@ describe('cliui', function () {
         { text: ' [required] [default: 99]', align: 'right' }
       )
 
-      var expected = [
+      const expected = [
         'i am a string that will be',
         'wrapped         [required] [default: 99]'
       ]
@@ -302,8 +300,8 @@ describe('cliui', function () {
       ui.toString().split('\n').should.eql(expected)
     })
 
-    it('does not append the string if it does not fit on the prior row', function () {
-      var ui = cliui({
+    it('does not append the string if it does not fit on the prior row', () => {
+      const ui = cliui({
         width: 40
       })
 
@@ -315,7 +313,7 @@ describe('cliui', function () {
         { text: 'i am a second row', align: 'left' }
       )
 
-      var expected = [
+      const expected = [
         'i am a string that will be',
         'wrapped',
         'i am a second row'
@@ -324,8 +322,8 @@ describe('cliui', function () {
       ui.toString().split('\n').should.eql(expected)
     })
 
-    it('always appends text to prior span if wrap is disabled', function () {
-      var ui = cliui({
+    it('always appends text to prior span if wrap is disabled', () => {
+      const ui = cliui({
         wrap: false,
         width: 40
       })
@@ -340,7 +338,7 @@ describe('cliui', function () {
 
       ui.div('a third line')
 
-      var expected = [
+      const expected = [
         'i am a string that will be wrapped   i am a second row',
         'a third line'
       ]
@@ -348,8 +346,8 @@ describe('cliui', function () {
       ui.toString().split('\n').should.eql(expected)
     })
 
-    it('appends to prior line appropriately when strings contain ansi escape codes', function () {
-      var ui = cliui({
+    it('appends to prior line appropriately when strings contain ansi escape codes', () => {
+      const ui = cliui({
         width: 40
       })
 
@@ -361,20 +359,18 @@ describe('cliui', function () {
         { text: chalk.blue(' [required] [default: 99]'), align: 'right' }
       )
 
-      var expected = [
+      const expected = [
         'i am a string that will be',
         'wrapped         [required] [default: 99]'
       ]
 
-      ui.toString().split('\n').map(function (l) {
-        return stripAnsi(l)
-      }).should.eql(expected)
+      ui.toString().split('\n').map(l => stripAnsi(l)).should.eql(expected)
     })
   })
 
-  describe('layoutDSL', function () {
-    it('turns tab into multiple columns', function () {
-      var ui = cliui({
+  describe('layoutDSL', () => {
+    it('turns tab into multiple columns', () => {
+      const ui = cliui({
         width: 60
       })
 
@@ -382,7 +378,7 @@ describe('cliui', function () {
         '  <regex>  \tmy awesome regex\n  <my second thing>  \tanother row\t  a third column'
       )
 
-      var expected = [
+      const expected = [
         '  <regex>            my awesome regex',
         '  <my second thing>  another row          a third column'
       ]
@@ -390,15 +386,15 @@ describe('cliui', function () {
       ui.toString().split('\n').should.eql(expected)
     })
 
-    it('turns newline into multiple rows', function () {
-      var ui = cliui({
+    it('turns newline into multiple rows', () => {
+      const ui = cliui({
         width: 40
       })
 
       ui.div(
         'Usage: $0\n  <regex>\t  my awesome regex\n  <glob>\t  my awesome glob\t  [required]'
       )
-      var expected = [
+      const expected = [
         'Usage: $0',
         '  <regex>  my awesome regex',
         '  <glob>   my awesome     [required]',
@@ -408,8 +404,8 @@ describe('cliui', function () {
       ui.toString().split('\n').should.eql(expected)
     })
 
-    it('aligns rows appropriately when they contain ansi escape codes', function () {
-      var ui = cliui({
+    it('aligns rows appropriately when they contain ansi escape codes', () => {
+      const ui = cliui({
         width: 40
       })
 
@@ -417,25 +413,23 @@ describe('cliui', function () {
         '  <regex>\t  ' + chalk.red('my awesome regex') + '\t  [regex]\n  ' + chalk.blue('<glob>') + '\t  my awesome glob\t  [required]'
       )
 
-      var expected = [
+      const expected = [
         '  <regex>  my awesome     [regex]',
         '           regex',
         '  <glob>   my awesome     [required]',
         '           glob'
       ]
 
-      ui.toString().split('\n').map(function (l) {
-        return stripAnsi(l)
-      }).should.eql(expected)
+      ui.toString().split('\n').map(l => stripAnsi(l)).should.eql(expected)
     })
 
-    it('ignores ansi escape codes when measuring padding', function () {
+    it('ignores ansi escape codes when measuring padding', () => {
       // Forcefully enable color-codes for this test
       const { enabled, level } = chalk
       chalk.enabled = true
       chalk.level = 1
 
-      var ui = cliui({
+      const ui = cliui({
         width: 25
       })
 
@@ -445,7 +439,7 @@ describe('cliui', function () {
       )
 
       // relevant part is first line - leading whitespace should be preserved as left padding
-      var expected = [
+      const expected = [
         '  |',
         '  __|   __|  |   |   _ \\',
         '  |    |     |   |   __/',
@@ -453,15 +447,13 @@ describe('cliui', function () {
         '                         '
       ]
 
-      ui.toString().split('\n').map(function (l) {
-        return stripAnsi(l)
-      }).should.eql(expected)
+      ui.toString().split('\n').map(l => stripAnsi(l)).should.eql(expected)
       chalk.enabled = enabled
       chalk.level = level
     })
 
-    it('correctly handles lack of ansi escape codes when measuring padding', function () {
-      var ui = cliui({
+    it('correctly handles lack of ansi escape codes when measuring padding', () => {
+      const ui = cliui({
         width: 25
       })
 
@@ -471,7 +463,7 @@ describe('cliui', function () {
       )
 
       // The difference
-      var expected = [
+      const expected = [
         '  |',
         '  __|   __|  |   |   _ \\',
         '  |    |     |   |   __/',
@@ -479,13 +471,11 @@ describe('cliui', function () {
         ''
       ]
 
-      ui.toString().split('\n').map(function (l) {
-        return stripAnsi(l)
-      }).should.eql(expected)
+      ui.toString().split('\n').map(l => stripAnsi(l)).should.eql(expected)
     })
 
-    it('does not apply DSL if wrap is false', function () {
-      var ui = cliui({
+    it('does not apply DSL if wrap is false', () => {
+      const ui = cliui({
         width: 40,
         wrap: false
       })


### PR DESCRIPTION
This maintains compatibility with node.js 6.  Additional improvements can be made once it's time to drop node.js 6, for example using `String#padStart` and `String#padEnd`.