### PR TITLE
fix(exports): node 13.0-13.6 require a string fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "version": "7.0.1",
   "description": "easily create complex multi-column command-line-interfaces",
   "main": "build/index.cjs",
-  "exports": {
-    "import": "./index.mjs",
-    "require": "./build/index.cjs"
-  },
+  "exports": [
+    {
+      "import": "./index.mjs",
+      "require": "./build/index.cjs"
+    },
+    "./build/index.cjs"
+  ],
   "type": "module",
   "module": "./index.mjs",
   "scripts": {


### PR DESCRIPTION
package.json’s "engines" field claims cliui supports node >= 10; node v13.0-v13.6 are included in this semver range. This change is required to be able to require() from cli-ui successfully in these versions.

See https://github.com/yargs/yargs/pull/1776