### PR TITLE
fix(deno): import UIOptions from definitions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: bcoe/release-please-action@v2.5.5
+      - uses: bcoe/release-please-action@v2.6.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/deno.ts
+++ b/deno.ts
@@ -1,5 +1,6 @@
 // Bootstrap cliui with CommonJS dependencies:
-import { cliui, UIOptions, UI } from './build/lib/index.js'
+import { cliui, UI } from './build/lib/index.js'
+import type { UIOptions } from './build/lib/index.d.ts'
 import { wrap, stripAnsi } from './build/lib/string-utils.js'
 
 export default function ui (opts: UIOptions): UI {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,7 +12,7 @@ const left = 3
 
 export interface UIOptions {
   width: number;
-  wrap: boolean;
+  wrap?: boolean;
   rows?: string[];
 }
 
@@ -47,7 +47,7 @@ export class UI {
 
   constructor (opts: UIOptions) {
     this.width = opts.width
-    this.wrap = opts.wrap
+    this.wrap = opts.wrap ?? false
     this.rows = []
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -47,7 +47,7 @@ export class UI {
 
   constructor (opts: UIOptions) {
     this.width = opts.width
-    this.wrap = opts.wrap ?? false
+    this.wrap = opts.wrap ?? true
     this.rows = []
   }
 
@@ -384,6 +384,6 @@ export function cliui (opts: Partial<UIOptions> = {}, _mixin: Mixin) {
   mixin = _mixin
   return new UI({
     width: opts.width || getWindowWidth(),
-    wrap: opts.wrap !== false
+    wrap: opts.wrap
   })
 }


### PR DESCRIPTION
I"m not quite sure why this was working before, UIOptions should have been imported from the definitions.