### PR TITLE
chore(deps): update dependency strip-ansi to v6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "license": "ISC",
   "dependencies": {
     "string-width": "^4.2.0",
-    "strip-ansi": "^6.0.0",
+    "strip-ansi": "^6.0.1",
     "wrap-ansi": "^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
update dependency strip-ansi` to v6.0.1.
strip-ansi@6.0.0 has ReDos issue.

# Contexts
https://github.com/yargs/yargs/issues/1839#issuecomment-930323243
https://github.com/chalk/strip-ansi/releases/tag/v6.0.1
https://github.com/chalk/ansi-regex/releases/tag/v5.0.1