### PR TITLE
fix: updates for ansi-regex 5.0.1 and CVE-2021-3807

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "license": "ISC",
   "dependencies": {
     "string-width": "^4.2.0",
-    "strip-ansi": "^6.0.0",
+    "strip-ansi": "^6.0.1",
     "wrap-ansi": "^7.0.0"
   },
   "devDependencies": {
@@ -66,7 +66,7 @@
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-node": "^11.1.0",
     "gts": "^3.0.0",
-    "mocha": "^8.1.1",
+    "mocha": "^9.1.3",
     "rimraf": "^3.0.2",
     "rollup": "^2.23.1",
     "standardx": "^7.0.0",


### PR DESCRIPTION
This updates strip-ansi and mocha to pick up
ansi-regex 5.0.1 for CVE-2021-3807 [1][2].

[1] https://nvd.nist.gov/vuln/detail/CVE-2021-3807
[2] https://github.com/advisories/GHSA-93q8-gq69-wqmw

Closes #111