### PR TITLE
chore(ts): small tweaks to make typescript happier

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -204,7 +204,7 @@ export class UI {
     const match = source.match(/^ */)
     const leadingWhitespace = match ? match[0].length : 0
     const target = previousLine.text
-    const targetTextWidth = mixin.stringWidth(target.trimRight())
+    const targetTextWidth = mixin.stringWidth(target.trimEnd())
 
     if (!previousLine.span) {
       return source
@@ -223,13 +223,13 @@ export class UI {
 
     previousLine.hidden = true
 
-    return target.trimRight() + ' '.repeat(leadingWhitespace - targetTextWidth) + source.trimLeft()
+    return target.trimEnd() + ' '.repeat(leadingWhitespace - targetTextWidth) + source.trimStart()
   }
 
   private rasterize (row: ColumnArray) {
     const rrows: string[][] = []
     const widths = this.columnWidths(row)
-    let wrapped
+    let wrapped: string[]
 
     // word wrap all columns, and create
     // a data-structure that is easy to rasterize.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es2017",
     "moduleResolution": "node",
     "module": "es2015"
-  },  
+  },
   "include": [
     "lib/**/*.ts"
   ],


### PR DESCRIPTION
- Use trimStart/trimEnd instead of deprecated trimLeft/trimRight
- Target es2019, which is when trimLeft/Right/Start/End methods became available (at least according to tsc)