### PR TITLE
test: add watch run-script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "compile": "tsc",
     "postcompile": "npm run build:cjs",
     "build:cjs": "rollup -c",
-    "prepare": "npm run compile"
+    "prepare": "npm run compile",
+    "watch": "rimraf build && tsc -p tsconfig.test.json && concurrently npm:watch:tsc npm:watch:cjs",
+    "watch:cjs": "cross-env NODE_ENV=test rollup -w -c",
+    "watch:tsc": "tsc -p tsconfig.test.json --watch"
   },
   "repository": "yargs/cliui",
   "standard": {
@@ -60,6 +63,7 @@
     "c8": "^7.3.0",
     "chai": "^4.2.0",
     "chalk": "^4.1.0",
+    "concurrently": "^8.0.1",
     "cross-env": "^7.0.2",
     "eslint": "^7.6.0",
     "eslint-plugin-import": "^2.22.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "c8": "^7.3.0",
     "chai": "^4.2.0",
     "chalk": "^4.1.0",
-    "concurrently": "^8.0.1",
+    "concurrently": "^7.6.0",
     "cross-env": "^7.0.2",
     "eslint": "^7.6.0",
     "eslint-plugin-import": "^2.22.0",


### PR DESCRIPTION
Add a `watch` run-script as a minor developer convenience.

I was following this PR in [yargs](https://github.com/yargs/yargs/pull/2320), but this time I noticed that it would be better if all the watch compiles used the test configurations. I'll go back and tune the yargs scripts accordingly!

