### PR TITLE
feat: add default width to Deno implementation

### DIFF
--- a/deno.ts
+++ b/deno.ts
@@ -1,10 +1,19 @@
+/* global Deno */
+
 // Bootstrap cliui with CommonJS dependencies:
 import { cliui, UI } from './build/lib/index.js'
 import type { UIOptions } from './build/lib/index.d.ts'
 import { wrap, stripAnsi } from './build/lib/string-utils.js'
 
 export default function ui (opts: UIOptions): UI {
-  return cliui(opts, {
+  const optsWithWidth = opts ?? {}
+  if (!optsWithWidth.width) {
+    const { columns } = Deno.consoleSize()
+    if (columns) {
+      optsWithWidth.width = columns
+    }
+  }
+  return cliui(optsWithWidth, {
     stringWidth: (str: string) => {
       return [...str].length
     },


### PR DESCRIPTION
Just a small improvement. Use `Deno.consoleSize` to supply default value for column width.

- https://deno.land/api@v1.34.0?unstable&s=Deno.consoleSize

Noted in:  https://github.com/yargs/cliui/issues/132#issuecomment-1546542214 and was included in closed #140