### PR TITLE
fix: make internal options and opt.width optional and match implementation

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -380,7 +380,7 @@ function alignCenter (str: string, width: number): string {
 }
 
 let mixin: Mixin
-export function cliui (opts: Partial<UIOptions>, _mixin: Mixin) {
+export function cliui (opts: Partial<UIOptions> | undefined, _mixin: Mixin) {
   mixin = _mixin
   return new UI({
     width: opts?.width || getWindowWidth(),


### PR DESCRIPTION
The documentation says the client can optionally supply options, and can optionally supply opt.width. The implementation supports this, but the typings did not. This is a minor change to match the intended and implemented client interface.

Fixes: #132

Side note: the type definition files are not being fully published currently. This PR improves the types but does not change what is published. One thing at a time.