### PR TITLE
fix: update typings to accept zero arguments

### DIFF
--- a/deno.ts
+++ b/deno.ts
@@ -3,7 +3,7 @@ import { cliui, UI } from './build/lib/index.js'
 import type { UIOptions } from './build/lib/index.d.ts'
 import { wrap, stripAnsi } from './build/lib/string-utils.js'
 
-export default function ui (opts: UIOptions): UI {
+export default function ui (opts?: UIOptions): UI {
   return cliui(opts, {
     stringWidth: (str: string) => {
       return [...str].length

--- a/lib/cjs.ts
+++ b/lib/cjs.ts
@@ -3,7 +3,7 @@ import { cliui, UIOptions } from './index.js'
 const stringWidth = require('string-width')
 const stripAnsi = require('strip-ansi')
 const wrap = require('wrap-ansi')
-export default function ui (opts: UIOptions) {
+export default function ui (opts?: UIOptions) {
   return cliui(opts, {
     stringWidth,
     stripAnsi,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -380,7 +380,7 @@ function alignCenter (str: string, width: number): string {
 }
 
 let mixin: Mixin
-export function cliui (opts: Partial<UIOptions>, _mixin: Mixin) {
+export function cliui (opts: Partial<UIOptions> | undefined | null, _mixin: Mixin) {
   mixin = _mixin
   return new UI({
     width: opts?.width || getWindowWidth(),


### PR DESCRIPTION
The default export for cliui is a function that takes 1 or 0 arguments, as indicated in the examples in the readme. This updates the typescript typings so that passing zero arguments is valid
