### PR TITLE
fix: make require("cliui") work as expected for CJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,14 @@ easily create complex multi-column command-line-interfaces.
 
 ## Example
 
+```bash
+npm i cliui@latest chalk@latest
+```
+
 ```js
 const ui = require('cliui')()
+const {Chalk} = require('chalk');
+const chalk = new Chalk();
 
 ui.div('Usage: $0 [command] [options]')
 
@@ -46,7 +52,9 @@ As of `v7` `cliui` supports [Deno](https://github.com/denoland/deno) and
 [ESM](https://nodejs.org/api/esm.html#esm_ecmascript_modules):
 
 ```typescript
-import cliui from "https://deno.land/x/cliui/deno.ts";
+import cliui from "cliui";
+import chalk from "chalk";
+// Deno: import cliui from "https://deno.land/x/cliui/deno.ts";
 
 const ui = cliui({})
 
@@ -57,11 +65,23 @@ ui.div({
   padding: [2, 0, 1, 0]
 })
 
-ui.div({
-  text: "-f, --file",
-  width: 20,
-  padding: [0, 4, 0, 4]
-})
+ui.div(
+  {
+    text: "-f, --file",
+    width: 20,
+    padding: [0, 4, 0, 4]
+  },
+  {
+    text: "the file to load." +
+      chalk.green("(if this description is long it wraps).")
+    ,
+    width: 20
+  },
+  {
+    text: chalk.red("[required]"),
+    align: 'right'
+  }
+)
 
 console.log(ui.toString())
 ```

--- a/index.mjs
+++ b/index.mjs
@@ -11,3 +11,5 @@ export default function ui (opts) {
     wrap: wrapAnsi
   })
 }
+
+export {ui as 'module.exports'};


### PR DESCRIPTION
@shadowspawn this uses the suggestion you gave in yargs adding:

```js
export {ui as 'module.exports'};
```

Which seemed to make things work pretty well for both CJS and ESM:

```js
const ui = require('cliui')()
const {Chalk} = require('chalk')
const chalk = new Chalk();
ui.div('Usage: $0 [command] [options]')

ui.div({
  text: 'Options:',
  padding: [2, 0, 1, 0]
})
```

```js
import cliui from "cliui";
import chalk from "chalk";
// Deno: import cliui from "https://deno.land/x/cliui/deno.ts";

const ui = cliui({})
```

Thoughts? Do you think this hack (`export {ui as 'module.exports'};`) is reasonable, or is it going to bite us one day.