### PR TITLE
chore: stop publishing tsconfig.tsbuildinfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   "files": [
     "build",
     "index.mjs",
-    "!*.d.ts"
+    "!*.d.ts",
+    "!*.tsbuildinfo"
   ],
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
This file:
* accounts for roughly two thirds of cliui's package size (both packed and unpacked)
* creates a false/irrelevant mismatch if someone security-conscious naively tries to verify that building cliui from source produces the same output as is published on npm (since building in a fresh clone of the repo will *not* generate an identical `tsconfig.tsbuildinfo` to the published one)
* has no reason at all to be published as far as I understand it; per https://www.typescriptlang.org/tsconfig/#tsBuildInfoFile I understand it to be for incremental builds, and https://www.reddit.com/r/typescript/comments/14ejrlk/should_i_publish_the_tsconfigtsbuildinfo/ says not to publish it.