### PR TITLE
refactor: replace strip-ansi with native node util

### DIFF
--- a/deno.ts
+++ b/deno.ts
@@ -2,13 +2,13 @@
 import { cliui, UI } from './build/lib/index.js'
 import type { UIOptions } from './build/lib/index.d.ts'
 import stringWidth from 'string-width'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters } from 'node:util'
 import wrapAnsi from 'wrap-ansi'
 
 export default function ui (opts: UIOptions): UI {
   return cliui(opts, {
     stringWidth,
-    stripAnsi,
+    stripAnsi: stripVTControlCharacters,
     wrap: wrapAnsi
   })
 }

--- a/index.mjs
+++ b/index.mjs
@@ -1,13 +1,13 @@
 // Bootstrap cliui with CommonJS dependencies:
 import { cliui } from './build/lib/index.js'
 import stringWidth from 'string-width'
-import stripAnsi from 'strip-ansi'
 import wrapAnsi from 'wrap-ansi'
+import { stripVTControlCharacters } from 'node:util'
 
 export default function ui (opts) {
   return cliui(opts, {
     stringWidth,
-    stripAnsi,
+    stripAnsi: stripVTControlCharacters,
     wrap: wrapAnsi
   })
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "license": "ISC",
   "dependencies": {
     "string-width": "^7.2.0",
-    "strip-ansi": "^7.1.0",
     "wrap-ansi": "^9.0.0"
   },
   "devDependencies": {

--- a/test/cliui.mjs
+++ b/test/cliui.mjs
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import cliui from '../index.mjs'
-import stripAnsi from 'strip-ansi'
+import { stripVTControlCharacters as stripAnsi } from 'node:util'
 import { should } from 'chai'
 
 /* global describe, it */


### PR DESCRIPTION
## Overview

This pull request replaces `strip-ansi` dependency with native Node util [`stripVTControlCharacters`](https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr) that do the same thing.

This utility is available since Node 16.11